### PR TITLE
fixed ScannerError issue while running tests for cfme-5.7.1 and above

### DIFF
--- a/cfme-performance/utils/appliance.py
+++ b/cfme-performance/utils/appliance.py
@@ -77,7 +77,7 @@ def get_vmdb_yaml_config(ssh_client):
     ver = get_version()
     if ver == '56' or ver == '57':
         base_data = ssh_client.run_rails_command(
-            'puts\(Settings.to_hash.deep_stringify_keys.to_yaml\)')
+            'puts\(Settings.to_hash.deep_stringify_keys.to_yaml\)', ignore_stderr=True)
         if base_data.rc:
             logger.error("Config couldn't be found")
             logger.error(base_data.output)


### PR DESCRIPTION
This commit is to resolve the issue mentioned here : https://github.com/redhat-performance/cfme-performance/issues/4
@arcolife @psuriset can you merge it.