### PR TITLE
[Fixes #46]Allow Configuring dnsmasq

### DIFF
--- a/ansible/configure/dnsmasq.yml
+++ b/ansible/configure/dnsmasq.yml
@@ -1,0 +1,12 @@
+---
+#
+# Post deployment of appliance automation
+#
+
+- hosts: all
+  gather_facts: false
+  vars_files:
+    - ../group_vars/all.yml
+    - ../group_vars/all.local.yml
+  roles:
+    - dnsmasq

--- a/ansible/configure/roles/dnsmasq/tasks/main.yaml
+++ b/ansible/configure/roles/dnsmasq/tasks/main.yaml
@@ -1,0 +1,21 @@
+...
+  - name: Install dnsmasq
+    shell:
+       yum install dnsmasq -y
+  - name: Configure the hostname to ip remap
+    lineinfile:
+         dest: /etc/dnsmasq.conf
+         regexp: '^address='
+         line: 'address=/{{ hostname_map }}/{{ remap_ip }}'
+         state: present
+  - name: Configure the resolv.conf to use dnsmasq
+    lineinfile:
+         dest: /etc/resolv.conf
+         line: 'nameserver 127.0.0.1'
+         state: present
+  - name: Start the dnsmasq service
+    shell:
+       systemctl start dnsmasq
+  - name: Check if we are able to ping a host or not
+    shell:
+       ping -c 1 "{{ hostname_map }}"


### PR DESCRIPTION
PR adds the ansible roles for configuring dnsmasq service
and using it for resolving hostnames to our simulated providers.

Signed-off-by: Saurabh Badhwar <sbadhwar@redhat.com>